### PR TITLE
Persist active account using local storage

### DIFF
--- a/src/account/AccountContext.tsx
+++ b/src/account/AccountContext.tsx
@@ -4,8 +4,10 @@ import { PalletSocietyBid } from '@polkadot/types/lookup'
 import React, { useContext, useEffect, useState } from 'react'
 import { useSubstrate } from '../substrate'
 
+const storedActiveAccount = localStorage.getItem("activeAccount") || ''
+
 const INIT_STATE = {
-  activeAccount: '',
+  activeAccount: storedActiveAccount,
   setActiveAccount: () => ({}),
   accounts: [],
   setAccounts: () => ({}),
@@ -24,7 +26,7 @@ const AccountContext = React.createContext<StateType>(INIT_STATE)
 
 const AccountContextProvider = ({ children } : any) => {
   const { api } = useSubstrate()
-  const [activeAccount, setActiveAccount] = useState<string>('')
+  const [activeAccount, setActiveAccount] = useState<string>(storedActiveAccount)
   const [accounts, setAccounts] = useState<{ name: string | undefined; address: string }[]>([])
   const [level, setLevel] = useState("human")
 

--- a/src/components/AccountSelector.tsx
+++ b/src/components/AccountSelector.tsx
@@ -20,6 +20,7 @@ const Main = () => {
 
   const onChange = (account: HTMLInputElement) => {
     setActiveAccount(account.innerText)
+    localStorage.setItem("activeAccount", account.innerText)
   }
 
   const Title = () => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,9 +33,9 @@ const NavbarBrand = () => (
 )
 
 const AccountNavbar = () => {
-  const { activeAccount, setActiveAccount, accounts, setAccounts } = useAccount()
+  const { activeAccount, setActiveAccount, setAccounts } = useAccount()
 
-  return accounts.length != 0 && activeAccount
+  return activeAccount
     ? <AccountSelector />
     : (
       <Button variant="outline-secondary" onClick={() => fetchAccounts(setAccounts, setActiveAccount)}>

--- a/src/helpers/fetchAccounts.ts
+++ b/src/helpers/fetchAccounts.ts
@@ -24,6 +24,7 @@ const fetchAccounts = (
 
       setAccounts(accounts)
       setActiveAccount(accounts[0].address)
+      localStorage.setItem("activeAccount", accounts[0].address)
     } catch (e) {
       console.error(e)
     }


### PR DESCRIPTION
I was studying some other web3 applications like https://singular.rmrk.app/ and https://apps.karura.network/ and found out they persist the last active account using local storage. This way the user doesn't need to connect his wallet everytime the page is refreshed.