### PR TITLE
Instead of disabling the button, make it connect to the first available account when clicked

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,8 +3,8 @@ import { Link, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { useAccount } from '../account/AccountContext'
 import { PrimaryLgButton } from '../components/base'
-import Canary from '../static/canary.svg'
 import { fetchAccounts } from '../helpers/fetchAccounts'
+import Canary from '../static/canary.svg'
 import KappaSigmaMuTitle from '../static/kappa-sigma-mu-title.svg'
 
 const LandingPage = () => {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -15,7 +15,7 @@ const LandingPage = () => {
     if (!activeAccount) {
       fetchAccounts(setAccounts, setActiveAccount)
     }
-    navigate('/welcome')
+    navigate('/cyborg-guide')
   }
 
   return (

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -5,10 +5,18 @@ import { useAccount } from '../account/AccountContext'
 import { PrimaryLgButton } from '../components/base'
 import Canary from '../static/canary.svg'
 import KappaSigmaMuTitle from '../static/kappa-sigma-mu-title.svg'
+import { fetchAccounts } from '../helpers/fetchAccounts'
 
 const LandingPage = () => {
-  const { activeAccount } = useAccount()
   const navigate = useNavigate()
+  const { activeAccount, setActiveAccount, setAccounts } = useAccount()
+
+  const handlePrimaryButtonClick = () => {
+    if (!activeAccount) {
+      fetchAccounts(setAccounts, setActiveAccount)
+    }
+    navigate('/welcome')
+  }
 
   return (
     <>
@@ -20,7 +28,7 @@ const LandingPage = () => {
           <h1>Join the</h1>
           <KappaSigmaMu src={KappaSigmaMuTitle} alt="Kappa Sigma Mu Title" />
           <p>
-            <PrimaryLgButton disabled={!activeAccount} onClick={() => { navigate('/welcome') }}>
+            <PrimaryLgButton onClick={handlePrimaryButtonClick}>
               Become a Cyborg
             </PrimaryLgButton>
           </p>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components'
 import { useAccount } from '../account/AccountContext'
 import { PrimaryLgButton } from '../components/base'
 import Canary from '../static/canary.svg'
-import KappaSigmaMuTitle from '../static/kappa-sigma-mu-title.svg'
 import { fetchAccounts } from '../helpers/fetchAccounts'
+import KappaSigmaMuTitle from '../static/kappa-sigma-mu-title.svg'
 
 const LandingPage = () => {
   const navigate = useNavigate()


### PR DESCRIPTION
If the user has not connected the wallet and clicks on the `Become a Cyborg` button, it requests a connection to the wallet. Also, it nows send the user to cyborg guide (temporarily just for the release)